### PR TITLE
Fix textInput on IOS

### DIFF
--- a/src/Fable.Helpers.ReactNative.fs
+++ b/src/Fable.Helpers.ReactNative.fs
@@ -1439,7 +1439,8 @@ let inline text (props:TextProperties list) (text:string): React.ReactElement =
     createElement(RN.Text, props, [React.str text])
 
 let inline textInput (props: ITextInputProperties list) (text:string): React.ReactElement =
-    createElement(RN.TextInput, props, [R.str text])
+    let valueProp = TextInput.TextInputProperties.Value text :> ITextInputProperties
+    createElement(RN.TextInput, valueProp :: props, [])
 
 let inline createToolbarAction(title:string,showStatus:ToolbarActionShowStatus) : ToolbarAndroidAction =
     createObj [


### PR DESCRIPTION
I think this should solve the issue being seen in https://github.com/fable-compiler/fable-react-native/issues/17. Instead of having the text field string value be a child, it is instead passed in as a property.