### PR TITLE
FlatList fixes

### DIFF
--- a/src/Fable.Helpers.ReactNative.fs
+++ b/src/Fable.Helpers.ReactNative.fs
@@ -1595,12 +1595,22 @@ let inline listView<'a> (dataSource:ListViewDataSource<'a>) (props: IListViewPro
             createObj ["dataSource" ==> dataSource],
             keyValueList CaseRules.LowerFirst props), [])
 
-let inline flatList<'a> (data:'a []) (props: IFlatListProperties<'a> list)  : React.ReactElement =
+let inline flatList<'a> (data:'a []) (props: FlatListProperties<'a> list)  : React.ReactElement =
+    let pascalCaseProps, camelCaseProps =
+      List.partition (function
+                      | ItemSeparatorComponent _ -> true
+                      | ListEmptyComponent _ -> true
+                      | ListFooterComponent _ -> true
+                      | ListHeaderComponent _ -> true
+                      | _ -> false)
+                      props
+
     createElementWithObjProps(
       RN.FlatList,
       !!JS.Object.assign(
             createObj ["data" ==> data],
-            keyValueList CaseRules.LowerFirst props), [])
+            keyValueList CaseRules.LowerFirst camelCaseProps,
+            keyValueList CaseRules.None pascalCaseProps), [])
 
 let inline mapView (props:IMapViewProperties list) (children: React.ReactElement list): React.ReactElement =
     createElement(


### PR DESCRIPTION
Some of FlatList properties are upper case:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts#L3608-L3623

Note that I have changed `props: IFlatListProperties` to `props: FlatListProperties` to make it built. Not sure if it is ok.