### PR TITLE
Various fixes

### DIFF
--- a/src/Fable.Helpers.ReactNative.fs
+++ b/src/Fable.Helpers.ReactNative.fs
@@ -119,7 +119,7 @@ module Props =
     | Contain
     | Cover
     | Stretch
-    | Conter
+    | Center
     | Repeat
 
     [<StringEnum; RequireQualifiedAccess>]
@@ -214,6 +214,13 @@ module Props =
         | Visible | Hidden
 
     [<StringEnum; RequireQualifiedAccess>]
+    type ImageURISourceCache =
+        | Default
+        | Reload
+        | [<CompiledName("force-cache")>] ForceCache
+        | [<CompiledName("only-if-cached")>] OnlyIfCached
+
+    [<StringEnum; RequireQualifiedAccess>]
     type Behavior =
         | Height | Position | Padding
 
@@ -292,6 +299,9 @@ module Props =
     type Direction =
         | Horizontal | Vertical
 
+    type IImageSource =
+        interface end
+
     type ISizeUnit =
         interface end
 
@@ -299,9 +309,6 @@ module Props =
         interface end
 
     type IScrollViewStyle =
-        inherit IStyle
-
-    type ISwitchIOSStyle =
         inherit IStyle
 
     type ITextStyle =
@@ -362,9 +369,6 @@ module Props =
         interface end
 
     type ISliderProperties =
-        interface end
-
-    type ISliderIOSProperties =
         interface end
 
     type ITabBarItemProperties =
@@ -430,13 +434,76 @@ module Props =
         inherit IProgressViewIOSProperties
         inherit IRefreshControlProperties
         inherit ISliderProperties
-        inherit ISliderIOSProperties
         inherit ITabBarItemProperties
         inherit ITabBarIOSProperties
         inherit IScrollViewProperties
         inherit IStatusBarProperties
         inherit ISwitchProperties
         inherit IMapViewProperties
+
+    type WebViewPropertiesAndroid =
+        | JavaScriptEnabled of bool
+        | DomStorageEnabled of bool
+        interface IWebViewPropertiesAndroid
+
+    type WebViewPropertiesIOS =
+        | AllowsInlineMediaPlayback of bool
+        | Bounces of bool
+        | DecelerationRate of DecelerationRate
+        | OnShouldStartLoadWithRequest of (WebViewIOSLoadRequestEvent -> bool)
+        | ScrollEnabled of bool
+        interface IWebViewPropertiesIOS
+
+    type WebViewBundleSource =
+        | Uri of string
+        | Method of string
+        | Headers of obj
+        | Cache of Image
+        | Body of string
+
+    type WebViewHtmlSource =
+        | Html of string // REQUIRED!
+        | BaseUrl of string
+
+    type WebViewProperties =
+        | AutomaticallyAdjustContentInsets of bool
+        | Bounces of bool
+        | ContentInset of Insets
+        | Html of string
+        | InjectedJavaScript of string
+        | OnError of (NavState -> unit)
+        | OnLoad of (NavState -> unit)
+        | OnLoadEnd of (NavState -> unit)
+        | OnLoadStart of (NavState -> unit)
+        | OnNavigationStateChange of (NavState -> unit)
+        | OnShouldStartLoadWithRequest of (obj -> bool)
+        | RenderError of (unit -> React.ReactElement)
+        | RenderLoading of (unit -> React.ReactElement)
+        | ScrollEnabled of bool
+        | StartInLoadingState of bool
+        | Style of IStyle list
+        | Url of string
+        | Source of U3<WebViewUriSource, WebViewHtmlSource, float>
+        | MediaPlaybackRequiresUserAction of bool
+        | ScalesPageToFit of bool
+        | Ref of Ref<obj>
+        interface IWebViewProperties
+
+    type ImageURISourceProperties =
+        | Uri of string
+        | Bundle of string
+        | Method of string
+        | Headers of obj
+        | Body of string
+        | Cache of ImageURISourceCache
+        | Width of float
+        | Height of float
+        | Scale of float
+
+    type ImageSource =
+        | Remote of ImageURISourceProperties list
+        | Local of string
+        | RemoteList of ImageURISourceProperties list list
 
     type ITouchable =
         inherit IScrollViewProperties
@@ -683,10 +750,10 @@ module Props =
             | Actions of ToolbarAndroidAction []
             | ContentInsetEnd of float
             | ContentInsetStart of float
-            | Logo of obj
-            | NavIcon of obj
+            | Logo of IImageSource
+            | NavIcon of IImageSource
             | OnIconClicked of (unit -> unit)
-            | OverflowIcon of obj
+            | OverflowIcon of IImageSource
             | Rtl of bool
             | Style of IStyle list
             | Subtitle of string
@@ -755,59 +822,12 @@ module Props =
         | Ref of Ref<obj>
         interface IKeyboardAvoidingViewProps
 
-    type WebViewPropertiesAndroid =
-        | JavaScriptEnabled of bool
-        | DomStorageEnabled of bool
-        interface IWebViewPropertiesAndroid
-
-    type WebViewPropertiesIOS =
-        | AllowsInlineMediaPlayback of bool
-        | Bounces of bool
-        | DecelerationRate of DecelerationRate
-        | OnShouldStartLoadWithRequest of (WebViewIOSLoadRequestEvent -> bool)
-        | ScrollEnabled of bool
-        interface IWebViewPropertiesIOS
-
-    type WebViewUriSource =
-        | Uri of string
-        | Method of string
-        | Headers of obj
-        | Body of string
-
-    type WebViewHtmlSource =
-        | Html of string // REQUIRED!
-        | BaseUrl of string
-
-    type WebViewProperties =
-        | AutomaticallyAdjustContentInsets of bool
-        | Bounces of bool
-        | ContentInset of Insets
-        | Html of string
-        | InjectedJavaScript of string
-        | OnError of (NavState -> unit)
-        | OnLoad of (NavState -> unit)
-        | OnLoadEnd of (NavState -> unit)
-        | OnLoadStart of (NavState -> unit)
-        | OnNavigationStateChange of (NavState -> unit)
-        | OnShouldStartLoadWithRequest of (obj -> bool)
-        | RenderError of (unit -> React.ReactElement)
-        | RenderLoading of (unit -> React.ReactElement)
-        | ScrollEnabled of bool
-        | StartInLoadingState of bool
-        | Style of IStyle list
-        | Url of string
-        | Source of U3<WebViewUriSource, WebViewHtmlSource, float>
-        | MediaPlaybackRequiresUserAction of bool
-        | ScalesPageToFit of bool
-        | Ref of Ref<obj>
-        interface IWebViewProperties
-
     type SegmentedControlIOSProperties =
         | Enabled of bool
         | Momentary of bool
         | OnChange of (NativeSyntheticEvent<NativeSegmentedControlIOSChangeEvent> -> unit)
         | OnValueChange of (string -> unit)
-        | SelectedIndex of float
+        | SelectedIndex of int
         | TintColor of string
         | Values of ResizeArray<string>
         | Ref of Ref<SegmentedControlIOS>
@@ -923,8 +943,8 @@ module Props =
             | Progress of float
             | ProgressTintColor of string
             | TrackTintColor of string
-            | ProgressImage of obj
-            | TrackImage of obj
+            | ProgressImage of IImageSource
+            | TrackImage of IImageSource
             | Ref of Ref<ProgressViewIOS>
             interface IProgressViewIOSProperties
 
@@ -951,19 +971,22 @@ module Props =
         | Ref of Ref<RefreshControl>
         interface IRefreshControlProperties
 
-    type SliderPropertiesIOS =
-        | MaximumTrackImage of obj
-        | MaximumTrackTintColor of string
-        | MinimumTrackImage of string
-        | MinimumTrackTintColor of string
-        | ThumbImage of obj
-        | TrackImage of obj
-        | Ref of Ref<Slider>
+    type SliderIOSProperties =
+        | TrackImage of IImageSource
+        | MinimumTrackImage of IImageSource
+        | MaximumTrackImage of IImageSource
+        | ThumbImage of IImageSource
+        interface ISliderProperties
+
+    type SliderAndroidProperties =
+        | ThumbTintColor of string
         interface ISliderProperties
 
     type SliderProperties =
         | Disabled of bool
+        | MaximumTrackTintColor of string
         | MaximumValue of float
+        | MinimumTrackTintColor of string
         | MinimumValue of float
         | OnSlidingComplete of (float -> unit)
         | OnValueChange of (float -> unit)
@@ -971,31 +994,19 @@ module Props =
         | Style of IStyle list
         | TestID of string
         | Value of float
+        | Ref of Ref<Slider>
         interface ISliderProperties
 
-    type SliderIOSProperties =
-        | Disabled of bool
-        | MaximumValue of float
-        | MaximumTrackTintColor of string
-        | MinimumValue of float
-        | MinimumTrackImage of obj
-        | MinimumTrackTintColor of string
-        | OnSlidingComplete of (unit -> unit)
-        | OnValueChange of (float -> unit)
-        | Step of float
-        | Style of IStyle list
-        | Value of float
-        | Ref of Ref<SliderIOS>
-        interface ISliderIOSProperties
-
-    type SwitchIOSProperties =
+    type SwitchProperties =
         | Disabled of bool
         | OnTintColor of string
         | OnValueChange of (bool -> unit)
         | ThumbTintColor of string
         | TintColor of string
         | Value of bool
-        | Style of IStyle list
+        | TestID of string
+        | Ref of Ref<Switch>
+        interface ISwitchProperties
 
     type ImageStyle =
         | ResizeMode of string
@@ -1020,30 +1031,23 @@ module Props =
     type IImageProperties =
         inherit IImagePropertiesIOS
 
-    type IImageSourceProperties =
-        interface end
-
-    type ImageSourceProperties =
-        | Uri of string
-        | IsStatic of bool
-        interface IImageSourceProperties
-
     type ImagePropertiesIOS =
         | AccessibilityLabel of string
         | Accessible of bool
         | CapInsets of Insets
-        | DefaultSource of IImageSourceProperties list
+        | DefaultSource of IImageSource
         | OnError of (obj -> unit)
         | OnProgress of (unit -> unit)
         interface IImagePropertiesIOS
 
     type ImageProperties =
+        | BlurRadius of float
         | OnLayout of (LayoutChangeEvent -> unit)
         | OnLoad of (unit -> unit)
         | OnLoadEnd of (unit -> unit)
         | OnLoadStart of (unit -> unit)
         | ResizeMode of ResizeMode
-        | Source of IImageSourceProperties list
+        | Source of IImageSource
         | Style of IStyle list
         | TestID of string
         interface IImageProperties
@@ -1307,12 +1311,16 @@ module Props =
     | Always
     | Handled
 
-    type ScrollViewProperties =
+    type ScrollViewProperties<'a> =
         | ContentContainerStyle of ViewStyle list
         | Horizontal of bool
         | KeyboardDismissMode of string
         | KeyboardShouldPersistTaps of KeyboardShouldPersistTapsProperties
         | OnScroll of (obj -> unit)
+        | OnScrollBeginDrag of (obj -> unit)
+        | OnScrollEndDrag of (obj -> unit)
+        | OnMomentumScrollBegin of (obj -> unit)
+        | OnMomentumScrollEnd of (obj -> unit)
         | PagingEnabled of bool
         | RemoveClippedSubviews of bool
         | ShowsHorizontalScrollIndicator of bool
@@ -1321,6 +1329,7 @@ module Props =
         | RefreshControl of React.ReactElement
         | Ref of Ref<ScrollView>
         interface IScrollViewProperties
+        interface IFlatListProperties<'a>
 
     type ListViewProperties<'a> =
         | DataSource of ListViewDataSource<'a>
@@ -1357,6 +1366,7 @@ module Props =
         | ListFooterComponent of (unit -> React.ReactElement)
         | ListHeaderComponent of (unit -> React.ReactElement)
         | ColumnWrapperStyle of IStyle list
+        | ContentContainerStyle of IStyle list
         | ExtraData of obj
         | GetItemLayout of (ResizeArray<'a> -> GetItemLayoutResult)
         | Horizontal of bool
@@ -1372,6 +1382,8 @@ module Props =
         | Refreshing of bool
         | RemoveClippedSubviews of bool
         | RenderItem of (FlatListRenderItemInfo<'a> -> React.ReactElement)
+        | ScrollEnabled of bool
+        | Style of IStyle list
         | ViewabilityConfig of ViewabilityConfig
         | Ref of Ref<obj>
         interface IFlatListProperties<'a>
@@ -1430,20 +1442,6 @@ module Props =
         | Hidden of bool
         interface IStatusBarProperties
 
-    type SwitchPropertiesIOS =
-        | OnTintColor of string
-        | ThumbTintColor of string
-        | TintColor of string
-        | Ref of Ref<Switch>
-        interface ISwitchProperties
-
-    type SwitchProperties =
-        | Disabled of bool
-        | TestID of string
-        | Style of IStyle list
-        | Ref of Ref<Switch>
-        interface ISwitchProperties
-
     type NavigationAnimatedViewProps =
         | Route of obj
         | Style of IStyle list
@@ -1491,15 +1489,21 @@ module R = Fable.Helpers.React
 
 [<Emit("$0")>]
 // density independent pixels
-let Dip (_: float): ISizeUnit = jsNative
+let dip (_: float): ISizeUnit = jsNative
 
 [<Emit("$0 + \"%\"")>]
 // percents
-let Pct (_: float): ISizeUnit = jsNative
+let pct (_: float): ISizeUnit = jsNative
 
 [<Emit("require($0)")>]
 // Use `require` to load a local image
-let inline localImage (path:string) : IImageSourceProperties list = jsNative
+let inline localImage (_path:string) : IImageSource = jsNative
+
+let inline remoteImage (source: ImageURISourceProperties list) =
+  unbox<IImageSource> (keyValueList CaseRules.LowerFirst source)
+
+let inline remoteImages (sources: ImageURISourceProperties list array) =
+  unbox<IImageSource> (Array.map remoteImage sources)
 
 let inline createElement(c: React.ComponentClass<'T>, props: 'P list, children: React.ReactElement list) =
     R.createElement (c, keyValueList CaseRules.LowerFirst props, children)
@@ -1520,7 +1524,7 @@ let inline createToolbarAction(title:string,showStatus:ToolbarActionShowStatus) 
         "show" ==> showStatus
     ]
 
-let inline createToolbarActionWithIcon(title:string,icon: IImageSourceProperties list,showStatus:ToolbarActionShowStatus) : ToolbarAndroidAction =
+let inline createToolbarActionWithIcon(title:string,icon: IImageSource,showStatus:ToolbarActionShowStatus) : ToolbarAndroidAction =
     createObj [
         "title" ==> title
         "icon" ==> icon
@@ -1621,14 +1625,9 @@ let inline slider (props:ISliderProperties list) : React.ReactElement =
       RN.Slider,
       props, [])
 
-let inline sliderIOS (props:ISliderIOSProperties list) : React.ReactElement =
+let inline switch (props:ISwitchProperties list) : React.ReactElement =
     createElement(
-      RN.SliderIOS,
-      props, [])
-
-let inline switchIOS (props:SwitchIOSProperties list) : React.ReactElement =
-    createElement(
-      RN.SwitchIOS,
+      RN.Switch,
       props, [])
 
 let inline image (props:IImageProperties list) : React.ReactElement =
@@ -1649,7 +1648,7 @@ let inline listView<'a> (dataSource:ListViewDataSource<'a>) (props: IListViewPro
             createObj ["dataSource" ==> dataSource],
             keyValueList CaseRules.LowerFirst props), [])
 
-let inline flatList<'a> (data:'a []) (props: FlatListProperties<'a> list)  : React.ReactElement =
+let inline flatList<'a> (data:'a []) (props: IFlatListProperties<'a> list)  : React.ReactElement =
     // Some of FlatList properties are upper case:
     // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts#L3608-L3623
     let pascalCaseProps, camelCaseProps =
@@ -1659,7 +1658,7 @@ let inline flatList<'a> (data:'a []) (props: FlatListProperties<'a> list)  : Rea
                       | ListFooterComponent _ -> true
                       | ListHeaderComponent _ -> true
                       | _ -> false)
-                      props
+                      (unbox<FlatListProperties<'a> list> props)
 
     createElementWithObjProps(
       RN.FlatList,
@@ -1752,14 +1751,6 @@ let inline statusBar (props:IStatusBarProperties list) : React.ReactElement =
     createElement(
       RN.StatusBar,
       props, [])
-
-let inline switch (props:ISwitchProperties list) (onValueChange: bool -> unit) (value:bool) : React.ReactElement =
-    createElementWithObjProps(
-      RN.Switch,
-      !!JS.Object.assign(
-            createObj ["onValueChange" ==> onValueChange
-                       "value" ==> value],
-            keyValueList CaseRules.LowerFirst props), [])
 
 let inline navigationHeader (props:INavigationHeaderProps list) (rendererProps:NavigationTransitionProps): React.ReactElement =
     createElementWithObjProps(

--- a/src/Fable.Helpers.ReactNative.fs
+++ b/src/Fable.Helpers.ReactNative.fs
@@ -500,11 +500,6 @@ module Props =
         | Height of float
         | Scale of float
 
-    type ImageSource =
-        | Remote of ImageURISourceProperties list
-        | Local of string
-        | RemoteList of ImageURISourceProperties list list
-
     type ITouchable =
         inherit IScrollViewProperties
         inherit IMapViewProperties

--- a/src/Fable.Import.ReactNative.fs
+++ b/src/Fable.Import.ReactNative.fs
@@ -349,7 +349,7 @@ module ReactNative =
         | [<CompiledName("space-between")>] SpaceBetween
         | [<CompiledName("space-around")>] SpaceAround
 
-    and [<StringEnum>] FlexDisplayType =
+    and [<StringEnum; RequireQualifiedAccess>] FlexDisplayType =
         | None | Flex
 
     and [<StringEnum>] FlexDirectionType =
@@ -797,7 +797,7 @@ module ReactNative =
 
     and NativeSegmentedControlIOSChangeEvent =
         abstract value: string with get, set
-        abstract selectedSegmentIndex: float with get, set
+        abstract selectedSegmentIndex: int with get, set
         abstract target: float with get, set
 
     and SegmentedControlIOSProperties =
@@ -1038,72 +1038,35 @@ module ReactNative =
         inherit React.ComponentClass<RefreshControlProperties>
         abstract SIZE: obj with get, set
 
-    and SliderPropertiesIOS =
-        inherit ViewProperties
-        inherit React.Props<SliderStatic>
-        abstract maximumTrackImage: obj option with get, set
-        abstract maximumTrackTintColor: string option with get, set
-        abstract minimumTrackImage: string option with get, set
-        abstract minimumTrackTintColor: string option with get, set
-        abstract thumbImage: obj option with get, set
+    and SliderIOSProperties =
         abstract trackImage: obj option with get, set
-        abstract ref: Ref<SliderStatic> option with get, set
+        abstract minimumTrackImage: obj option with get, set
+        abstract maximumTrackImage: obj option with get, set
+        abstract thumbImage: obj option with get, set
+
+    and SliderAndroidProperties =
+        abstract thumbTintColor: string option with get, set
 
     and SliderProperties =
-        inherit SliderPropertiesIOS
+        inherit ViewProperties
+        inherit SliderIOSProperties
+        inherit SliderAndroidProperties
         inherit React.Props<SliderStatic>
-        abstract disabled: bool option with get, set
-        abstract maximumValue: float option with get, set
-        abstract minimumValue: float option with get, set
-        abstract onSlidingComplete: (float -> unit) option with get, set
-        abstract onValueChange: (float -> unit) option with get, set
-        abstract step: float option with get, set
         abstract style: ViewStyle option with get, set
-        abstract testID: string option with get, set
         abstract value: float option with get, set
+        abstract step: float option with get, set
+        abstract minimumValue: float option with get, set
+        abstract maximumValue: float option with get, set
+        abstract minimumTrackTintColor: string option with get, set
+        abstract maximumTrackTintColor: string option with get, set
+        abstract disabled: bool option with get, set
+        abstract onValueChange: (float -> unit) option with get, set
+        abstract onSlidingComplete: (float -> unit) option with get, set
+        abstract testID: string option with get, set
+        abstract ref: Ref<SliderStatic> option with get, set
 
     and SliderStatic =
         inherit React.ComponentClass<SliderProperties>
-
-
-    and SliderIOSProperties =
-        inherit ViewProperties
-        inherit React.Props<SliderIOSStatic>
-        abstract disabled: bool option with get, set
-        abstract maximumValue: float option with get, set
-        abstract maximumTrackTintColor: string option with get, set
-        abstract minimumValue: float option with get, set
-        abstract minimumTrackImage: obj option with get, set
-        abstract minimumTrackTintColor: string option with get, set
-        abstract onSlidingComplete: (unit -> unit) option with get, set
-        abstract onValueChange: (float -> unit) option with get, set
-        abstract step: float option with get, set
-        abstract style: ViewStyle option with get, set
-        abstract value: float option with get, set
-        abstract ref: Ref<SliderIOSStatic> option with get, set
-
-    and SliderIOSStatic =
-        inherit React.ComponentClass<SliderIOSProperties>
-
-
-    and SwitchIOSStyle =
-        inherit ViewStyle
-        abstract height: float option with get, set
-        abstract width: float option with get, set
-
-    and SwitchIOSProperties =
-        inherit React.Props<SwitchIOSStatic>
-        abstract disabled: bool option with get, set
-        abstract onTintColor: string option with get, set
-        abstract onValueChange: (bool -> unit) option with get, set
-        abstract thumbTintColor: string option with get, set
-        abstract tintColor: string option with get, set
-        abstract value: bool option with get, set
-        abstract style: SwitchIOSStyle option with get, set
-
-    and SwitchIOSStatic =
-        inherit React.ComponentClass<SwitchIOSProperties>
-
 
     and ImageResizeModeStatic =
         abstract contain: string with get, set
@@ -1139,6 +1102,7 @@ module ReactNative =
     and ImageProperties =
         inherit ImagePropertiesIOS
         inherit React.Props<Image>
+        abstract blurRadius: float option with get, set
         abstract onLayout: (LayoutChangeEvent -> unit) option with get, set
         abstract onLoad: (unit -> unit) option with get, set
         abstract onLoadEnd: (unit -> unit) option with get, set
@@ -1596,6 +1560,10 @@ module ReactNative =
         abstract keyboardDismissMode: string option with get, set
         abstract keyboardShouldPersistTaps: bool option with get, set
         abstract onScroll: (obj -> unit) option with get, set
+        abstract onScrollBeginDrag: (obj -> unit) option with get, set
+        abstract onScrollEndDrag: (obj -> unit) option with get, set
+        abstract onMomentumScrollBegin: (obj -> unit) option with get, set
+        abstract onMomentumScrollEnd: (obj -> unit) option with get, set
         abstract pagingEnabled: bool option with get, set
         abstract removeClippedSubviews: bool option with get, set
         abstract showsHorizontalScrollIndicator: bool option with get, set
@@ -1927,22 +1895,16 @@ module ReactNative =
         abstract show: message: string * duration: float -> unit
         abstract showWithGravity: message: string * duration: float * gravity: float -> unit
 
-    and SwitchPropertiesIOS =
-        inherit ViewProperties
-        inherit React.Props<SwitchStatic>
-        abstract onTintColor: string option with get, set
-        abstract thumbTintColor: string option with get, set
-        abstract tintColor: string option with get, set
-        abstract ref: Ref<SwitchStatic> option with get, set
-
     and SwitchProperties =
         inherit ViewProperties
         inherit React.Props<SwitchStatic>
+        abstract value: bool option with get, set
         abstract disabled: bool option with get, set
         abstract onValueChange: (bool -> unit) option with get, set
         abstract testID: string option with get, set
-        abstract value: bool option with get, set
-        abstract style: ViewStyle option with get, set
+        abstract tintColor: string option with get, set
+        abstract onTintColor: string option with get, set
+        abstract thumbTintColor: string option with get, set
         abstract ref: Ref<SwitchStatic> option with get, set
 
     and SwitchStatic =
@@ -2200,10 +2162,7 @@ module ReactNative =
         RefreshControlStatic
 
     and Slider =
-        SliderIOS
-
-    and SliderIOS =
-        SliderIOSStatic
+        SliderStatic
 
     and StatusBar =
         StatusBarStatic
@@ -2219,9 +2178,6 @@ module ReactNative =
 
     and Switch =
         SwitchStatic
-
-    and SwitchIOS =
-        SwitchIOSStatic
 
     and TabBarIOS =
         TabBarIOSStatic
@@ -2378,14 +2334,12 @@ module ReactNative =
         [<Import("ProgressBarAndroid", "react-native")>] static member ProgressBarAndroid with get(): ProgressBarAndroidStatic = jsNative and set(v: ProgressBarAndroidStatic): unit = jsNative
         [<Import("ProgressViewIOS", "react-native")>] static member ProgressViewIOS with get(): ProgressViewIOSStatic = jsNative and set(v: ProgressViewIOSStatic): unit = jsNative
         [<Import("RefreshControl", "react-native")>] static member RefreshControl with get(): RefreshControlStatic = jsNative and set(v: RefreshControlStatic): unit = jsNative
-        [<Import("Slider", "react-native")>] static member Slider with get(): SliderIOS = jsNative and set(v: SliderIOS): unit = jsNative
-        [<Import("SliderIOS", "react-native")>] static member SliderIOS with get(): SliderIOSStatic = jsNative and set(v: SliderIOSStatic): unit = jsNative
+        [<Import("Slider", "react-native")>] static member Slider with get(): SliderStatic = jsNative and set(v: SliderStatic): unit = jsNative
         [<Import("StatusBar", "react-native")>] static member StatusBar with get(): StatusBarStatic = jsNative and set(v: StatusBarStatic): unit = jsNative
         [<Import("ScrollView", "react-native")>] static member ScrollView with get(): ScrollViewStatic = jsNative and set(v: ScrollViewStatic): unit = jsNative
         [<Import("StyleSheet", "react-native")>] static member StyleSheet with get(): StyleSheetStatic = jsNative and set(v: StyleSheetStatic): unit = jsNative
         [<Import("SwipeableListView", "react-native")>] static member SwipeableListView with get(): SwipeableListViewStatic<obj> = jsNative and set(v: SwipeableListViewStatic<obj>): unit = jsNative
         [<Import("Switch", "react-native")>] static member Switch with get(): SwitchStatic = jsNative and set(v: SwitchStatic): unit = jsNative
-        [<Import("SwitchIOS", "react-native")>] static member SwitchIOS with get(): SwitchIOSStatic = jsNative and set(v: SwitchIOSStatic): unit = jsNative
         [<Import("TabBarIOS", "react-native")>] static member TabBarIOS with get(): TabBarIOSStatic = jsNative and set(v: TabBarIOSStatic): unit = jsNative
         [<Import("Text", "react-native")>] static member Text with get(): TextStatic = jsNative and set(v: TextStatic): unit = jsNative
         [<Import("TextInput", "react-native")>] static member TextInput with get(): TextInputStatic = jsNative and set(v: TextInputStatic): unit = jsNative


### PR DESCRIPTION
- changed `IImageSourceProperties list` to `IImageSource` and added functions for fetching remote images `remoteImage` and `remoteImages`:
https://github.com/iyegoroff/fable-react-native/blob/ea8bf8ff51a1d702edb9db44620fb13a35194cfe/src/Fable.Helpers.ReactNative.fs#L1497-L1501
- updated `Switch` and `Slider` components;
- removed deprecated `SwitchIOS` and `SliderIOS` components;
- updated `FlatListProperties` and added `IFlatListProperties` interface to `ScrollViewProperties`;
- updated `ScrollViewProperties`;
- renamed function `Dip` to `dip` and `Pct` to `pct` to conform other function's naming style;
- put `WebViewBundleSource` above `ImageURISourceProperties`, so now `Uri` is inferred as `ImageURISourceProperties.Uri` which is more commonly used than `WebViewBundleSource.Uri`;
- added `RequireQualifiedAccess` to `FlexDisplayType` to prevent conflict with `Option.None`;
- several fixed typos & minor fixes;

